### PR TITLE
Use raw string for bedbase filter regex

### DIFF
--- a/geopephub/metageo_pephub.py
+++ b/geopephub/metageo_pephub.py
@@ -195,7 +195,7 @@ def _upload_gse_project(
     """
     if target == "bedbase":
         geofetcher_obj = geofetch.Geofetcher(
-            filter="\.(bed|bigBed|narrowPeak|broadPeak)\.",
+            filter=r"\.(bed|bigBed|narrowPeak|broadPeak)\.",
             filter_size=BEDBASE_MAX_SIZE,
             data_source="all",
             processed=True,


### PR DESCRIPTION
Fixes #26.

## Summary
- makes the bedbase GEO file filter regex a raw string
- preserves the existing pattern while avoiding Python 3.13+ invalid escape sequence warnings for `\.`

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- Relying on the GitHub Actions PR workflow for remote validation.