### PR TITLE
Automate GEO archive snapshots

### DIFF
--- a/.github/workflows/geo_archive.yml
+++ b/.github/workflows/geo_archive.yml
@@ -1,0 +1,89 @@
+name: Publish namespace archive
+
+# Produces a dated full-namespace archive by rehydrating the last published one
+# from S3, applying the update delta, and republishing. Stateless: nothing
+# persists between runs except the tar in the bucket.
+#
+# Dispatch-only for now. The schedule below stays commented until a dispatch run
+# has published a real archive; add it in a separate commit at that point.
+#
+#  schedule:
+#    # quarterly, 04:00 on the 1st of Jan/Apr/Jul/Oct
+#    - cron: '0 4 1 1,4,7,10 *'
+
+on:
+  workflow_dispatch:
+    inputs:
+      namespace:
+        description: 'Namespace to archive'
+        required: true
+        default: 'geo'
+        type: string
+      start_period:
+        description: "Delta start (YYYY/MM/DD). Blank = previous archive's date. Use 2024/09/06 for the backfill run"
+        required: false
+        default: ''
+        type: string
+      register:
+        description: 'Publish to S3 and write the archive row. Leave unchecked for a dry run'
+        required: true
+        default: false
+        type: boolean
+      workers:
+        description: 'Concurrent project fetches'
+        required: true
+        default: '4'
+        type: string
+      fail_threshold:
+        description: 'Abort without publishing if this fraction of fetches fail'
+        required: true
+        default: '0.01'
+        type: string
+
+jobs:
+  archive:
+    runs-on: ${{ matrix.os }}
+    # Under the 360-minute hard cap so a hang fails cleanly rather than being
+    # killed mid-upload. Backfill of ~41k projects measured well under this.
+    timeout-minutes: 330
+    strategy:
+      matrix:
+        python-version: [ "3.12" ]
+        os: [ ubuntu-latest ]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: python -m pip install .
+
+      - name: Disk before
+        run: df -h ${{ runner.temp }} /
+
+      - name: Build and publish archive
+        run: |
+          geopephub archive-update \
+            --namespace "${{ inputs.namespace }}" \
+            --workdir "${{ runner.temp }}/archive" \
+            --workers "${{ inputs.workers }}" \
+            --fail-threshold "${{ inputs.fail_threshold }}" \
+            ${{ inputs.start_period != '' && format('--start-period {0}', inputs.start_period) || '' }} \
+            ${{ inputs.register && '--register' || '--no-register' }}
+        env:
+          POSTGRES_DB: ${{ secrets.POSTGRES_DB }}
+          POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+          POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_PORT: ${{ secrets.POSTGRES_PORT }}
+          POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ENDPOINT_URL: ${{ secrets.AWS_ENDPOINT_URL }}
+
+      - name: Disk after
+        if: always()
+        run: df -h ${{ runner.temp }} /

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,8 +25,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install package
-      run: python -m pip install .
+      run: python -m pip install . pytest
 
     - name: Run help
       run: geopephub --help
+
+    - name: Run tests
+      run: pytest tests/ -v
 

--- a/geopephub/archive.py
+++ b/geopephub/archive.py
@@ -1,0 +1,365 @@
+# Full-namespace archive production (v2).
+#
+# v1 lives in bunch_geo.py and is intentionally left alone: it assumes a
+# destination directory that survives between runs, which is how the manual
+# Rivanna flow documented in the README works. This module assumes the
+# opposite -- nothing persists except the tar in S3 -- so it rehydrates the
+# previous archive, applies the delta, and republishes.
+
+import concurrent.futures
+import logging
+import os
+import shutil
+import tarfile
+from typing import Optional, Tuple
+
+import pepdbagent
+from pepdbagent.models import TarNamespaceModel
+from pephubclient.helpers import save_pep
+
+from geopephub.utils import date_today, get_agent, tar_folder
+
+_LOGGER = logging.getLogger(__name__)
+
+ARCHIVE_BUCKET = "pephub"
+PEPS_DIRNAME = "peps"
+
+# Sentinel start date for a cold start, matching v1's auto_run.
+EPOCH_START = "2000/01/01"
+
+
+def gse_shard(name: str) -> str:
+    """
+    Shard directory for a project NAME.
+
+    gse100000 -> gse100nnn
+    gse12345678 -> gse12345nnn
+    gse123 -> gsennn
+
+    utils.create_gse_sub_name does the same arithmetic but bunch_geo calls it
+    with the *namespace*, so every name is <= 6 chars and everything collapses
+    into one gsennn directory. This function exists to make the argument
+    unambiguous: it is always the project name.
+
+    :param name: project name, e.g. 'gse100000'
+    :return: shard directory name
+    """
+    if len(name) <= 6:
+        return "gsennn"
+    return name[:-3] + "nnn"
+
+
+def normalize_archive_key(file_path: str, bucket: str = ARCHIVE_BUCKET) -> str:
+    """
+    Recover the S3 object key from a stored archive file_path.
+
+    pepdbagent returns the raw column value ('geo/geo_2025_04_28.tar'), but the
+    pephub HTTP API rewrites it to an absolute CDN URL. Accept either so this
+    works against whichever one is handed to it.
+
+    :param file_path: value from TarNamespaceModel.file_path
+    :param bucket: bucket name to strip when the path is absolute
+    :return: object key relative to the bucket root
+    """
+    key = file_path
+    if key.startswith("http://") or key.startswith("https://"):
+        key = key.split("://", 1)[1]
+        key = key.split("/", 1)[1] if "/" in key else ""
+    key = key.lstrip("/")
+    prefix = f"{bucket}/"
+    if key.startswith(prefix):
+        key = key[len(prefix) :]
+    return key
+
+
+def count_projects(peps_dir: str) -> int:
+    """
+    Count PEPs actually present in the archive tree.
+
+    v1 registers agent.annotation.get(...).count -- the live namespace count --
+    which makes the number useless for spotting a short dump. This counts what
+    will really be in the tar.
+
+    :param peps_dir: the peps/ directory
+    :return: number of .zip files, recursively
+    """
+    total = 0
+    for _, _, files in os.walk(peps_dir):
+        total += sum(1 for f in files if f.endswith(".zip"))
+    return total
+
+
+def resolve_shards(peps_dir: str) -> int:
+    """
+    Move PEPs that landed in the wrong shard into the right one.
+
+    Repairs the flat peps/gsennn/ pile left by the create_gse_sub_name(namespace)
+    regression. Idempotent: a second call over a clean tree moves nothing.
+    Projects whose name is short enough to legitimately shard to 'gsennn' stay
+    where they are.
+
+    :param peps_dir: the peps/ directory
+    :return: number of files relocated
+    """
+    moved = 0
+    for shard in sorted(os.listdir(peps_dir)):
+        shard_path = os.path.join(peps_dir, shard)
+        if not os.path.isdir(shard_path):
+            continue
+        for filename in sorted(os.listdir(shard_path)):
+            if not filename.endswith(".zip"):
+                continue
+            correct = gse_shard(filename[: -len(".zip")])
+            if correct == shard:
+                continue
+            target_dir = os.path.join(peps_dir, correct)
+            os.makedirs(target_dir, exist_ok=True)
+            shutil.move(
+                os.path.join(shard_path, filename),
+                os.path.join(target_dir, filename),
+            )
+            moved += 1
+    if moved:
+        _LOGGER.info(f"Relocated {moved} projects into correct shard directories")
+    return moved
+
+
+def extract_archive(tar_path: str, destination: str) -> str:
+    """
+    Extract a published archive, returning the peps/ directory inside it.
+
+    v1 tars with arcname=basename(folder), so every member is rooted at 'peps/'.
+    Anything else means the tar was not produced by this pipeline and the run
+    should stop rather than build on top of an unknown layout.
+
+    :param tar_path: local path to the downloaded tar
+    :param destination: directory to extract into
+    :return: path to the extracted peps/ directory
+    """
+    os.makedirs(destination, exist_ok=True)
+    dest_real = os.path.realpath(destination)
+
+    # Python 3.14 makes 'data' the default extraction filter; opt in early where
+    # it exists so behavior does not shift under us.
+    extract_kwargs = {"filter": "data"} if hasattr(tarfile, "data_filter") else {}
+
+    with tarfile.open(tar_path, "r") as tar:
+        for member in tar:
+            root = member.name.split("/", 1)[0]
+            if root != PEPS_DIRNAME:
+                raise ValueError(
+                    f"Unexpected archive layout: member '{member.name}' is not "
+                    f"rooted at '{PEPS_DIRNAME}/'. Refusing to extract."
+                )
+            target = os.path.realpath(os.path.join(dest_real, member.name))
+            if not target.startswith(dest_real + os.sep):
+                raise ValueError(f"Archive member escapes destination: {member.name}")
+            tar.extract(member, path=dest_real, **extract_kwargs)
+
+    return os.path.join(destination, PEPS_DIRNAME)
+
+
+def download_previous_archive(
+    agent: pepdbagent.PEPDatabaseAgent,
+    namespace: str,
+    destination: str,
+    bucket: str = ARCHIVE_BUCKET,
+) -> Tuple[Optional[str], Optional[str]]:
+    """
+    Fetch the most recent published archive for a namespace.
+
+    :param agent: PEPDatabaseAgent
+    :param namespace: namespace to look up
+    :param destination: directory to download into
+    :param bucket: S3 bucket holding the archives
+    :return: (local tar path, start period as 'YYYY/MM/DD'), both None on cold start
+    """
+    import boto3
+
+    info = agent.namespace.get_tar_info(namespace=namespace)
+    if not info.count:
+        _LOGGER.info(f"No archive registered for '{namespace}'; starting from scratch")
+        return None, None
+
+    latest = info.results[0]
+    key = normalize_archive_key(latest.file_path, bucket=bucket)
+    local_path = os.path.join(destination, os.path.basename(key))
+
+    _LOGGER.info(f"Downloading previous archive s3://{bucket}/{key}")
+    os.makedirs(destination, exist_ok=True)
+    boto3.client("s3").download_file(bucket, key, local_path)
+
+    start_period = latest.creation_date.strftime("%Y/%m/%d")
+    _LOGGER.info(
+        f"Previous archive: {key} ({latest.number_of_projects} projects, "
+        f"created {start_period})"
+    )
+    return local_path, start_period
+
+
+def sync_delta(
+    agent: pepdbagent.PEPDatabaseAgent,
+    namespace: str,
+    peps_dir: str,
+    start_period: str,
+    end_period: str,
+    workers: int = 4,
+) -> dict:
+    """
+    Download every project updated in the window and write it into the tree.
+
+    Filtering on last_update_date returns new *and* revised projects, so this
+    single pass covers both -- provided save_pep is allowed to overwrite. v1
+    passes force=False, so revisions raise PEPExistsError and get swallowed by a
+    "skipping" warning; that is why every project revised since Sept 2024 is
+    stale in the published archive. force=True here is the fix, and
+    PEPExistsError is deliberately not caught: if it fires, something is wrong
+    and the run should say so.
+
+    :param agent: PEPDatabaseAgent
+    :param namespace: namespace to sync
+    :param peps_dir: the peps/ directory to write into
+    :param start_period: earlier bound, 'YYYY/MM/DD'
+    :param end_period: later bound, 'YYYY/MM/DD'
+    :param workers: concurrent fetches; each opens its own session off the
+        shared engine, so keep this under the SQLAlchemy pool size
+    :return: {'attempted': int, 'written': int, 'failed': [(name, reason), ...]}
+    """
+    projects = agent.annotation.get_projects_list(
+        namespace=namespace,
+        limit=1000000,
+        order_by="update_date",
+        filter_by="last_update_date",
+        filter_start_date=start_period,
+        filter_end_date=end_period,
+    )
+    attempted = len(projects)
+    _LOGGER.info(
+        f"{attempted} projects updated between {start_period} and {end_period}"
+    )
+
+    failed = []
+    written = 0
+
+    def _fetch(registry_path) -> None:
+        project = agent.project.get(
+            namespace=registry_path.namespace,
+            name=registry_path.name,
+            tag=registry_path.tag,
+            raw=True,
+        )
+        target = os.path.join(peps_dir, gse_shard(registry_path.name))
+        os.makedirs(target, exist_ok=True)
+        save_pep(project, project_path=target, force=True, zip=True)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(_fetch, p): p for p in projects}
+        for done, future in enumerate(concurrent.futures.as_completed(futures), 1):
+            registry_path = futures[future]
+            try:
+                future.result()
+                written += 1
+            except Exception as e:
+                _LOGGER.warning(f"Failed: {registry_path.name}: {e}")
+                failed.append((registry_path.name, str(e)))
+            if done % 1000 == 0:
+                _LOGGER.info(f"  {done}/{attempted} processed")
+
+    _LOGGER.info(f"Delta complete: {written} written, {len(failed)} failed")
+    return {"attempted": attempted, "written": written, "failed": failed}
+
+
+def build_archive(
+    namespace: str = "geo",
+    workdir: str = None,
+    start_period: str = None,
+    workers: int = 4,
+    register: bool = True,
+    bucket: str = ARCHIVE_BUCKET,
+    fail_threshold: float = 0.01,
+) -> Optional[str]:
+    """
+    Produce a dated full-namespace archive without relying on persistent state.
+
+    Downloads the last published archive, applies the update delta, repairs
+    shard layout, re-tars, and (optionally) publishes and registers the result.
+
+    :param namespace: namespace to archive
+    :param workdir: scratch directory; needs roughly 5GB free for geo
+    :param start_period: override the delta start ('YYYY/MM/DD'). Defaults to the
+        previous archive's creation date. Widen it to re-pull projects that
+        earlier runs skipped.
+    :param workers: concurrent project fetches
+    :param register: upload to S3 and write the archive row
+    :param bucket: S3 bucket
+    :param fail_threshold: abort without publishing if this fraction of fetches fail
+    :return: path to the new tar, or None if nothing was produced
+    """
+    if not workdir:
+        workdir = os.getcwd()
+    os.makedirs(workdir, exist_ok=True)
+
+    agent = get_agent()
+
+    previous_tar, previous_period = download_previous_archive(
+        agent, namespace, workdir, bucket=bucket
+    )
+
+    if previous_tar:
+        peps_dir = extract_archive(previous_tar, workdir)
+        os.remove(previous_tar)
+        _LOGGER.info(f"Rehydrated {count_projects(peps_dir)} projects from previous archive")
+    else:
+        peps_dir = os.path.join(workdir, PEPS_DIRNAME)
+        os.makedirs(peps_dir, exist_ok=True)
+
+    resolve_shards(peps_dir)
+
+    start = start_period or previous_period or EPOCH_START
+    stats = sync_delta(
+        agent,
+        namespace=namespace,
+        peps_dir=peps_dir,
+        start_period=start,
+        end_period=date_today(separator="/"),
+        workers=workers,
+    )
+
+    if stats["attempted"]:
+        failure_rate = len(stats["failed"]) / stats["attempted"]
+        if failure_rate > fail_threshold:
+            raise RuntimeError(
+                f"{len(stats['failed'])}/{stats['attempted']} fetches failed "
+                f"({failure_rate:.1%} > {fail_threshold:.1%}). Refusing to publish "
+                f"a partial archive."
+            )
+
+    tar_path = tar_folder(peps_dir, os.path.join(workdir, f"{namespace}_{date_today()}"))
+    actual = count_projects(peps_dir)
+    live = agent.annotation.get(namespace=namespace, limit=1).count
+    _LOGGER.info(f"Archived {actual} projects (live namespace count: {live})")
+    if actual != live:
+        _LOGGER.warning(
+            f"Archive holds {actual} projects but the namespace reports {live}. "
+            f"Deleted projects are never removed by a date-based delta; a digest "
+            f"manifest would be needed to reconcile this."
+        )
+
+    if not register:
+        _LOGGER.info(f"register=False; archive left at {tar_path}")
+        return tar_path
+
+    from geopephub.bunch_geo import upload_to_s3_file
+
+    object_name = f"{namespace}/{os.path.basename(tar_path)}"
+    upload_to_s3_file(file_name=os.path.abspath(tar_path), bucket=bucket, object_name=object_name)
+    agent.namespace.upload_tar_info(
+        TarNamespaceModel(
+            namespace=namespace,
+            file_path=object_name,
+            number_of_projects=actual,
+            file_size=os.stat(os.path.abspath(tar_path)).st_size,
+        )
+    )
+    _LOGGER.info(f"Published and registered {object_name}")
+    return tar_path

--- a/geopephub/cli.py
+++ b/geopephub/cli.py
@@ -1,5 +1,4 @@
 import typer
-from pandas.conftest import names
 
 from geopephub.metageo_pephub import (
     add_to_queue,
@@ -9,6 +8,7 @@ from geopephub.metageo_pephub import (
     clean_history as clean_history_function,
 )
 from geopephub.bunch_geo import bunch_geo, auto_run
+from geopephub.archive import build_archive
 from geopephub.__version__ import __version__
 
 app = typer.Typer()
@@ -255,6 +255,53 @@ def auto_download(
         tar_all=tar_all,
         upload_s3=upload_s3,
         bucket=bucket,
+    )
+
+
+@app.command(
+    help="Produce a dated full-namespace archive without persistent state: download the "
+    "last published archive, apply the update delta, re-tar, and publish. Intended for "
+    "unattended CI runs. Use auto-download instead when the destination survives between runs."
+)
+def archive_update(
+    namespace: str = typer.Option(
+        "geo",
+        help="Namespace to archive",
+    ),
+    workdir: str = typer.Option(
+        ...,
+        help="Scratch directory. Needs ~5GB free for the geo namespace",
+    ),
+    start_period: str = typer.Option(
+        None,
+        help="Override the delta start ['2024/09/06']. Defaults to the previous "
+        "archive's creation date. Widen it to re-pull projects earlier runs skipped",
+    ),
+    workers: int = typer.Option(
+        4,
+        help="Concurrent project fetches",
+    ),
+    register: bool = typer.Option(
+        True,
+        help="Upload to S3 and write the archive row. Set False for a dry run",
+    ),
+    bucket: str = typer.Option(
+        "pephub",
+        help="S3 bucket name",
+    ),
+    fail_threshold: float = typer.Option(
+        0.01,
+        help="Abort without publishing if this fraction of fetches fail",
+    ),
+) -> None:
+    build_archive(
+        namespace=namespace,
+        workdir=workdir,
+        start_period=start_period,
+        workers=workers,
+        register=register,
+        bucket=bucket,
+        fail_threshold=fail_threshold,
     )
 
 

--- a/tests/test_archive.py
+++ b/tests/test_archive.py
@@ -1,0 +1,228 @@
+"""Offline tests for the v2 archive builder. No database, no network."""
+
+import os
+import tarfile
+
+import pytest
+
+from geopephub.archive import (
+    count_projects,
+    extract_archive,
+    gse_shard,
+    normalize_archive_key,
+    resolve_shards,
+)
+from geopephub.utils import create_gse_sub_name, tar_folder
+
+
+def make_pep(peps_dir, shard, name):
+    """Drop a stand-in PEP zip into a shard directory."""
+    shard_dir = os.path.join(peps_dir, shard)
+    os.makedirs(shard_dir, exist_ok=True)
+    path = os.path.join(shard_dir, f"{name}.zip")
+    with open(path, "w") as f:
+        f.write(name)
+    return path
+
+
+class TestGseShard:
+    @pytest.mark.parametrize(
+        "name,expected",
+        [
+            ("gse100000", "gse100nnn"),
+            ("gse100999", "gse100nnn"),
+            ("gse271386", "gse271nnn"),
+            ("gse12345678", "gse12345nnn"),
+            ("gse1234567", "gse1234nnn"),
+            ("gse123456", "gse123nnn"),
+            ("gse1234", "gse1nnn"),
+            ("gse123", "gsennn"),
+            ("gse1", "gsennn"),
+        ],
+    )
+    def test_shards(self, name, expected):
+        assert gse_shard(name) == expected
+
+    def test_shard_is_stable(self):
+        """Re-sharding an already-correct name must not move it."""
+        for name in ["gse100000", "gse12345678", "gse123"]:
+            assert gse_shard(name) == gse_shard(name)
+
+    def test_namespace_argument_is_the_v1_bug(self):
+        """
+        Regression guard for commit 7cf93035.
+
+        v1 calls create_gse_sub_name(namespace); 'geo' is under the length
+        threshold so every project collapses into one directory. Pin that
+        behavior so it is obvious why v2 shards on the project name instead.
+        """
+        assert create_gse_sub_name("geo") == "gsennn"
+        assert create_gse_sub_name("bedbase") != "gsennn"
+        assert gse_shard("gse100000") == "gse100nnn"
+
+
+class TestNormalizeArchiveKey:
+    @pytest.mark.parametrize(
+        "stored,expected",
+        [
+            # what pepdbagent returns (raw column value)
+            ("geo/geo_2025_04_28.tar", "geo/geo_2025_04_28.tar"),
+            # what the pephub HTTP API returns
+            (
+                "https://cloud2.databio.org/pephub/geo/geo_2025_04_28.tar",
+                "geo/geo_2025_04_28.tar",
+            ),
+            ("http://cloud2.databio.org/pephub/geo/geo_2024_10_01.tar", "geo/geo_2024_10_01.tar"),
+            ("/geo/geo_2025_04_28.tar", "geo/geo_2025_04_28.tar"),
+            ("bedbase/bedbase_2025_01_01.tar", "bedbase/bedbase_2025_01_01.tar"),
+        ],
+    )
+    def test_normalize(self, stored, expected):
+        assert normalize_archive_key(stored) == expected
+
+
+class TestResolveShards:
+    def test_relocates_flat_pile(self, tmp_path):
+        """The gsennn pile left by the v1 regression gets redistributed."""
+        peps = str(tmp_path / "peps")
+        for name in ["gse100000", "gse100001", "gse271386", "gse12345678"]:
+            make_pep(peps, "gsennn", name)
+
+        moved = resolve_shards(peps)
+
+        assert moved == 4
+        assert os.path.exists(os.path.join(peps, "gse100nnn", "gse100000.zip"))
+        assert os.path.exists(os.path.join(peps, "gse100nnn", "gse100001.zip"))
+        assert os.path.exists(os.path.join(peps, "gse271nnn", "gse271386.zip"))
+        assert os.path.exists(os.path.join(peps, "gse12345nnn", "gse12345678.zip"))
+
+    def test_leaves_correct_shards_alone(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        make_pep(peps, "gse100nnn", "gse100000")
+        make_pep(peps, "gse271nnn", "gse271386")
+
+        assert resolve_shards(peps) == 0
+
+    def test_short_names_stay_in_gsennn(self, tmp_path):
+        """Names of 6 chars or fewer legitimately shard to gsennn."""
+        peps = str(tmp_path / "peps")
+        make_pep(peps, "gsennn", "gse123")
+        make_pep(peps, "gsennn", "gse1")
+
+        assert resolve_shards(peps) == 0
+        assert os.path.exists(os.path.join(peps, "gsennn", "gse123.zip"))
+        assert os.path.exists(os.path.join(peps, "gsennn", "gse1.zip"))
+
+    def test_idempotent(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        for name in ["gse100000", "gse271386"]:
+            make_pep(peps, "gsennn", name)
+
+        assert resolve_shards(peps) == 2
+        assert resolve_shards(peps) == 0
+
+    def test_preserves_project_count(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        names = ["gse100000", "gse100001", "gse271386", "gse123", "gse12345678"]
+        for name in names:
+            make_pep(peps, "gsennn", name)
+
+        before = count_projects(peps)
+        resolve_shards(peps)
+        assert count_projects(peps) == before == len(names)
+
+    def test_mixed_tree(self, tmp_path):
+        """A real archive: correct shards from Sept 2024 plus a later pile."""
+        peps = str(tmp_path / "peps")
+        make_pep(peps, "gse100nnn", "gse100000")
+        make_pep(peps, "gse271nnn", "gse271386")
+        make_pep(peps, "gsennn", "gse250000")
+        make_pep(peps, "gsennn", "gse260000")
+
+        assert resolve_shards(peps) == 2
+        assert count_projects(peps) == 4
+        assert os.path.exists(os.path.join(peps, "gse250nnn", "gse250000.zip"))
+        assert os.path.exists(os.path.join(peps, "gse100nnn", "gse100000.zip"))
+
+
+class TestCountProjects:
+    def test_counts_recursively(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        make_pep(peps, "gse100nnn", "gse100000")
+        make_pep(peps, "gse100nnn", "gse100001")
+        make_pep(peps, "gse271nnn", "gse271386")
+
+        assert count_projects(peps) == 3
+
+    def test_ignores_non_zip(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        make_pep(peps, "gse100nnn", "gse100000")
+        with open(os.path.join(peps, "gse100nnn", "README.md"), "w") as f:
+            f.write("not a pep")
+
+        assert count_projects(peps) == 1
+
+    def test_empty_tree(self, tmp_path):
+        peps = str(tmp_path / "peps")
+        os.makedirs(peps)
+        assert count_projects(peps) == 0
+
+
+class TestArchiveRoundTrip:
+    def test_tar_then_extract(self, tmp_path):
+        """tar_folder (v1) output must be readable by extract_archive (v2)."""
+        source = tmp_path / "source"
+        peps = str(source / "peps")
+        names = ["gse100000", "gse100001", "gse271386"]
+        for name in names:
+            make_pep(peps, gse_shard(name), name)
+
+        tar_path = tar_folder(peps, str(tmp_path / "geo_2026_07_31"))
+        assert tar_path.endswith(".tar")
+
+        extracted_root = tmp_path / "extracted"
+        peps_out = extract_archive(tar_path, str(extracted_root))
+
+        assert os.path.basename(peps_out) == "peps"
+        assert count_projects(peps_out) == len(names)
+        for name in names:
+            assert os.path.exists(os.path.join(peps_out, gse_shard(name), f"{name}.zip"))
+
+    def test_round_trip_is_stable_across_generations(self, tmp_path):
+        """Extract, add a project, re-tar, extract again -- the update cycle."""
+        peps = str(tmp_path / "gen1" / "peps")
+        make_pep(peps, "gse100nnn", "gse100000")
+        tar1 = tar_folder(peps, str(tmp_path / "gen1_archive"))
+
+        gen2 = tmp_path / "gen2"
+        peps2 = extract_archive(tar1, str(gen2))
+        make_pep(peps2, "gse271nnn", "gse271386")
+        tar2 = tar_folder(peps2, str(tmp_path / "gen2_archive"))
+
+        gen3 = tmp_path / "gen3"
+        peps3 = extract_archive(tar2, str(gen3))
+
+        assert count_projects(peps3) == 2
+        assert os.path.exists(os.path.join(peps3, "gse100nnn", "gse100000.zip"))
+        assert os.path.exists(os.path.join(peps3, "gse271nnn", "gse271386.zip"))
+
+    def test_rejects_unexpected_layout(self, tmp_path):
+        """A tar not rooted at peps/ must be refused, not silently built upon."""
+        stray = tmp_path / "elsewhere"
+        stray.mkdir()
+        (stray / "gse100000.zip").write_text("x")
+
+        tar_path = tar_folder(str(stray), str(tmp_path / "bad"))
+
+        with pytest.raises(ValueError, match="not rooted at"):
+            extract_archive(tar_path, str(tmp_path / "out"))
+
+    def test_rejects_path_traversal(self, tmp_path):
+        tar_path = str(tmp_path / "evil.tar")
+        payload = tmp_path / "payload"
+        payload.write_text("x")
+        with tarfile.open(tar_path, "w") as tar:
+            tar.add(str(payload), arcname="peps/../../escaped.zip")
+
+        with pytest.raises(ValueError):
+            extract_archive(tar_path, str(tmp_path / "out"))


### PR DESCRIPTION
PEPhub offers downloadable snapshots of the whole `geo` namespace at
`/geo?view=archive`. The newest one is from April 2025, because nothing has been
running the job that makes them.

This adds a command and a GitHub Action that keep them current. Rather than
rebuilding all 269,000 projects from the database each time, it downloads the
previous snapshot, updates only the projects that changed, and uploads the result.
That's around 6,000 projects in a typical quarterly run.

The existing `auto-download` command almost does this, but it only works when the
output folder is still sitting there from last time. That's true on Rivanna and
never true on a fresh CI machine. This PR leaves that command alone, so the Rivanna
instructions in the README keep working.

It also fixes some bugs found along the way:

- Every project was being written into a single folder instead of being split into
  subfolders by accession number. A refactor in 7cf93035 started passing the
  namespace ("geo") where the project name belonged. This version splits them
  correctly and tidies up the existing pile.
- Projects edited after they were first archived got silently skipped, so anything
  revised since September 2024 is out of date in the published snapshot.
- The project count saved with each snapshot came from the live database instead of
  being counted from the file, so it could never reveal a snapshot that came out
  short.
- The CLI imported a pandas test helper it never used, which crashes it on machines
  without a full timezone database.

If more than 1% of projects fail to download, it stops rather than publishing, so a
half-finished snapshot can't be mistaken for a complete one. The action is
manual-trigger only and defaults to not publishing anything. The quarterly schedule
stays commented out until a real run looks good.

Also adds the repo's first tests, 29 of them, and `pytest.yml` now actually runs
them instead of only checking that `--help` works.

Not handled: projects deleted from PEPhub still linger in the snapshot. Fixing that
needs a different approach and isn't part of this PR.
