### PR TITLE
Move logging setup out of __init__.py

### DIFF
--- a/geopephub/__init__.py
+++ b/geopephub/__init__.py
@@ -1,12 +1,3 @@
 from geopephub.__version__ import __version__
-import logmuse
-import coloredlogs
-
-_LOGGER = logmuse.init_logger("geopephub")
-coloredlogs.install(
-    logger=_LOGGER,
-    datefmt="%H:%M:%S",
-    fmt="[%(levelname)s] [%(asctime)s] %(message)s",
-)
 
 __all__ = ["__version__"]

--- a/geopephub/cli.py
+++ b/geopephub/cli.py
@@ -1,3 +1,4 @@
+import logmuse
 import typer
 
 from geopephub.metageo_pephub import (
@@ -340,5 +341,21 @@ def common(
     version: bool = typer.Option(
         False, "--version", "-v", callback=version_callback, is_eager=True, help="App version"
     ),
+    verbosity: int = typer.Option(
+        None, "--verbosity", help="Set logging level: 1 (CRITICAL) to 5 (DEBUG)"
+    ),
+    logdev: bool = typer.Option(False, "--logdev", help="Use developer logging format"),
+    silent: bool = typer.Option(False, "--silent", help="Silence logging"),
 ):
-    pass
+    # This callback runs before any command, so it is where logging gets
+    # configured. Don't move this into `__init__.py`.
+    logmuse.init_logger(
+        "geopephub",
+        verbosity=verbosity,
+        devmode=logdev,
+        silent=silent,
+        # Keep the "[INFO] [12:48:37] msg" format the scheduled workflows have
+        # always logged in. An explicit fmt overrides devmode, so skip it there.
+        fmt=None if logdev else "[%(levelname)s] [%(asctime)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )

--- a/geopephub/cli.py
+++ b/geopephub/cli.py
@@ -349,13 +349,4 @@ def common(
 ):
     # This callback runs before any command, so it is where logging gets
     # configured. Don't move this into `__init__.py`.
-    logmuse.init_logger(
-        "geopephub",
-        verbosity=verbosity,
-        devmode=logdev,
-        silent=silent,
-        # Keep the "[INFO] [12:48:37] msg" format the scheduled workflows have
-        # always logged in. An explicit fmt overrides devmode, so skip it there.
-        fmt=None if logdev else "[%(levelname)s] [%(asctime)s] %(message)s",
-        datefmt="%H:%M:%S",
-    )
+    logmuse.init_logger("geopephub", verbosity=verbosity, devmode=logdev, silent=silent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ geofetch = "^0.12.10"
 pepdbagent= "^0.12.2"
 #pepdbagent= { git = "https://github.com/pepkit/pepdbagent.git", branch = "dev" }
 SQLAlchemy = ">=2.0.0,<2.1.0"
-logmuse= ">=0.3.0"
+logmuse= ">=0.3.1"
 coloredlogs= "^15.0.1"
 peppy= "^0.40.7"
 pephubclient= "^0.4.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ geofetch = "^0.12.10"
 pepdbagent= "^0.12.2"
 #pepdbagent= { git = "https://github.com/pepkit/pepdbagent.git", branch = "dev" }
 SQLAlchemy = ">=2.0.0,<2.1.0"
-logmuse= ">=0.2.7"
+logmuse= ">=0.3.0"
 coloredlogs= "^15.0.1"
 peppy= "^0.40.7"
 pephubclient= "^0.4.4"


### PR DESCRIPTION
Importing geopephub used to configure logging as a side effect. `__init__.py` called `logmuse.init_logger()` and `coloredlogs.install()`, so anything that imported the package got handlers attached whether it wanted them or not.

That belongs at the entry point instead. geopephub is only ever run as a command, so the setup moved into the Typer callback, which runs before any subcommand.

This also adds `--verbosity`, `--logdev`, and `--silent`.

Log output is unchanged by default. The scheduled workflows call geopephub with no logging flags, and they still get INFO-level colored output in the same `[INFO] [12:48:37] message` format as before. logmuse 0.3.0 handles the coloring itself when coloredlogs is installed, so the explicit `coloredlogs.install()` call is gone.